### PR TITLE
Disable encoding on jelly pages that generate HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>emma</artifactId>
-  <version>1.30</version>
+  <version>1.31</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Emma plugin</name>

--- a/src/main/resources/hudson/plugins/emma/tags/breakdownTable.jelly
+++ b/src/main/resources/hudson/plugins/emma/tags/breakdownTable.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:e="/hudson/plugins/emma/tags">
   <table border="1px" class="sortable pane">
     <e:captionLine />

--- a/src/main/resources/hudson/plugins/emma/tags/summaryTable.jelly
+++ b/src/main/resources/hudson/plugins/emma/tags/summaryTable.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:e="/hudson/plugins/emma/tags">
   <table border="1px" class="pane">
     <e:captionLine />


### PR DESCRIPTION
Jenkins 2.146/2.138.2 changed the default setting for Jelly to encode by default.

https://www.stackovercloud.com/2018/10/11/important-security-updates-for-jenkins/

This causes HTML output from this plugin to be escaped, displaying to the user as the literal HTML text.

This change disables escaped-by-default on the two pages that generate HTML output directly.